### PR TITLE
Fix media import

### DIFF
--- a/drupal2wp/inc/Drupal2WordPressDrupalImporter_7.php
+++ b/drupal2wp/inc/Drupal2WordPressDrupalImporter_7.php
@@ -741,7 +741,7 @@ class Drupal2WordPressDrupalImporter_7 extends Drupal2WordPressDrupalVersionAdap
                 u.fid,
                 m.uri,
                 m.filename,
-                m.origname
+                m.uri
             FROM ".$this->dbSettings['prefix']."file_usage u
                 LEFT JOIN ".$this->dbSettings['prefix']."file_managed m ON (m.fid = u.fid)
             WHERE u.type = 'node'


### PR DESCRIPTION
On my Drupal install, I can't be able to import posts attached medias
Because of a bad request on bad field.

This commit fixes it.