### PR TITLE
Fix - query fail on big table

### DIFF
--- a/drupal2wp/inc/Drupal2WordPress_DrupalDB.php
+++ b/drupal2wp/inc/Drupal2WordPress_DrupalDB.php
@@ -248,6 +248,7 @@ class Drupal2WordPress_DrupalDB {
         $this->string_sanitize($args, TRUE);
         $query = preg_replace_callback(DB_QUERY_REGEXP, array(&$this, 'string_sanitize'), $sql['query']);
         mysqli_query($conn,"SET NAMES 'utf8'");
+        mysqli_query($conn,"SET SQL_BIG_SELECTS=1 ");
         $result = mysqli_query($conn, $query);
 
         if (!$result){


### PR DESCRIPTION
On a Wordpress with a lot of content mysql return this error:
#1104 - The SELECT would examine more than MAX_JOIN_SIZE rows; 
check your WHERE and use SET SQL_BIG_SELECTS=1 or SET MAX_JOIN_SIZE=# if the SELECT is okay